### PR TITLE
Move plugin dependencies to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     "webpack": "^4.21.0"
   },
   "peerDependencies": {
-    "babel-eslint": "^8.2.6",
+    "babel-eslint": "^10.0.1",
     "eslint": "^3.3.1 || ^4.6.1 || ^5.0.0",
-    "eslint-plugin-flowtype": "^2.50.0",
+    "eslint-plugin-flowtype": "^3.0.0",
     "eslint-plugin-import": "^2.13.0",
     "eslint-plugin-jsx-a11y": "^6.1.1",
     "eslint-plugin-react": "^7.10.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "eslint-config-wpcalypso": "^4.0.0",
     "eslint-loader": "^2.1.0",
-    "webpack": "^5.0.0"
+    "webpack": "^4.21.0"
   },
   "peerDependencies": {
     "babel-eslint": "^8.2.6",

--- a/package.json
+++ b/package.json
@@ -21,17 +21,18 @@
   },
   "homepage": "https://github.com/Automattic/eslint-config-wpvip#readme",
   "dependencies": {
-    "babel-eslint": "^8.2.6",
     "eslint-config-wpcalypso": "^4.0.0",
     "eslint-loader": "^2.1.0",
+    "webpack": "^5.0.0"
+  },
+  "peerDependencies": {
+    "babel-eslint": "^8.2.6",
+    "eslint": "^3.3.1 || ^4.6.1 || ^5.0.0",
     "eslint-plugin-flowtype": "^2.50.0",
     "eslint-plugin-import": "^2.13.0",
     "eslint-plugin-jsx-a11y": "^6.1.1",
     "eslint-plugin-react": "^7.10.0",
     "eslint-plugin-wpcalypso": "^4.0.1",
     "eslint-plugin-json": "^1.2.1"
-  },
-  "peerDependencies": {
-    "eslint": "^3.3.1 || ^4.6.1 || ^5.0.0"
   }
 }


### PR DESCRIPTION
Unfortunately, ESLint currently requires peer dependencies for plugins - it doesn't work reliably when they are defined as `dependencies`.

They're working on it: https://github.com/eslint/eslint/issues/10643

Fixes #2 