### PR TITLE
Add radix check as error

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,9 @@ module.exports = {
 			'warn',
 			'as-needed',
 		],
+		radix: [
+			'error',
+		],
 	},
 	settings: {
 		react: {


### PR DESCRIPTION
To enforce the radix param for `parseInt` calls.

Fixes #5 