### PR TITLE
Add no-unsafe-negation rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,9 @@ module.exports = {
 		'no-duplicate-imports': [
 			'warn',
 		],
+		'no-unsafe-negation': [
+			'error',
+		],
 		'max-len': [
 			'warn',
 			{


### PR DESCRIPTION
This prevents bugs when using `in` and `instanceof` in code that otherwise looks correct.

```
// Wrong and buggy as all get-out
if ( ! user instanceof User ) { ... }

// Correct
if ( ! ( user instanceof User ) ) { ... }
```

> Just as developers might type -a + b when they mean -(a + b) for the negative of a sum, they might type !key in object by mistake when they almost certainly mean !(key in object) to test that a key is not in an object. !obj instanceof Ctor is similar.

https://eslint.org/docs/rules/no-unsafe-negation