### PR TITLE
Add valid-typeof rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,6 +69,12 @@ module.exports = {
 		'no-async-foreach/no-async-foreach': [
 			'error',
 		],
+		'valid-typeof': [
+			'error',
+			{
+				requireStringLiterals: true,
+			},
+		],
 
 		// Jest rules, from https://github.com/jest-community/eslint-plugin-jest
 		'jest/consistent-test-it': 'error',


### PR DESCRIPTION
`undefined === typeof variable` is a big and hard to spot bug and should be blocked - must use literal `'undefined'`.

This will make all `typeof` checks more robust and easy to read by requiring literals.

It also catches typos (non-built-in-types):

```
typeof foo === "strnig"
typeof foo == "undefimed"
typeof bar != "nunber"
typeof bar !== "fucntion"
```

https://eslint.org/docs/rules/valid-typeof