### PR TITLE
Add comment style rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = {
 			},
 		],
 		'capitalized-comments': [
-			'error',
+			'warn',
 		],
 		'no-console': [
 			'warn',
@@ -73,7 +73,7 @@ module.exports = {
 			'error',
 		],
 		'spaced-comment': [
-			'error',
+			'warn',
 		],
 		'valid-typeof': [
 			'error',

--- a/index.js
+++ b/index.js
@@ -69,6 +69,9 @@ module.exports = {
 		'no-async-foreach/no-async-foreach': [
 			'error',
 		],
+		'spaced-comment': [
+			'error',
+		],
 		'valid-typeof': [
 			'error',
 			{

--- a/index.js
+++ b/index.js
@@ -35,6 +35,9 @@ module.exports = {
 				ignoreDestructuring: true,
 			},
 		],
+		'capitalized-comments': [
+			'error',
+		],
 		'no-console': [
 			'warn',
 		],


### PR DESCRIPTION
This PR enforces a space between the comment character and the comment itself, as well as enforces capitalized comments.

Correct:

```
// This is a comment
```

Incorrect:

```
//this is a comment
```