### PR TITLE
Error on `return await`

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,6 +81,10 @@ module.exports = {
 				requireStringLiterals: true,
 			},
 		],
+		
+		'no-return-await': [
+			'error',
+		],
 
 		// Jest rules, from https://github.com/jest-community/eslint-plugin-jest
 		'jest/consistent-test-it': 'error',

--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ module.exports = {
 				requireStringLiterals: true,
 			},
 		],
-		
+
 		'no-return-await': [
 			'error',
 		],


### PR DESCRIPTION
`return await` is redundant and "doesn’t actually do anything except add extra time before the overarching Promise resolves or rejects."

https://eslint.org/docs/rules/no-return-await