### PR TITLE
Remove the capitalized-comments Rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,9 +35,6 @@ module.exports = {
 				ignoreDestructuring: true,
 			},
 		],
-		'capitalized-comments': [
-			'warn',
-		],
 		'no-console': [
 			'warn',
 		],


### PR DESCRIPTION
While working with an auto-formatting setup (e.g. https://github.com/Automattic/vip-ui/pull/1137), this rule causes me frustration in the course of development :)

Namely, when I comment out a line of code for one reason or another and save, `eslint --fix` will "help" by capitalizing the first character of the line.

So, commenting out a line like:

`reticulate( splines );`

Upon save, it becomes:

`// Reticulate( splines );`

When it's time to reinstate the line, I then have to manually revert the line to lowercase.

Further, I'm not super in love with enforcing this across the board (but happy to discuss why it's a good idea if anyone likes!).