### PR TITLE
Add id-length rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,6 +78,13 @@ module.exports = {
 				requireStringLiterals: true,
 			},
 		],
+		'id-length': [
+			'warn',
+			{
+				min: 2,
+				max: 40,
+			},
+		],
 
 		'no-return-await': [
 			'error',


### PR DESCRIPTION
Checks the length of identifiers using ESLint and returns warnings for very short or very long IDs. This is not meant to fix hard to read variable names by itself or even meant to catch all names that are too short or too long. We're simply adding an automated check for the extreme cases.

https://eslint.org/docs/rules/id-length