### PR TITLE
Remove ignoreDestructuring from properties for 'camelcase' rule as it's not supported by ESLint anymore

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,6 @@ module.exports = {
 			'warn',
 			{
 				properties: 'never',
-				ignoreDestructuring: true,
 			},
 		],
 		'no-console': [


### PR DESCRIPTION
Fix for

```
wpvip:
	Configuration for rule "camelcase" is invalid:
	Value {"properties":"never","ignoreDestructuring":true} should NOT have additional properties.
```