### PR TITLE
Prefer arrow function callbacks

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,9 @@ module.exports = {
 				code: 200,
 			},
 		],
+		'prefer-arrow-callback': [
+			'warn',
+		],
 		'arrow-parens': [
 			'warn',
 			'as-needed',

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "ESLint configs to enforce VIP's (internal) JS coding standards",
   "main": "index.js",
   "scripts": {
-    "test": "eslint ."
+    "test": "npm run lint",
+	"lint": "eslint ."
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "npm run lint",
-	"lint": "eslint ."
+    "lint": "eslint ."
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds a new warning for anonymous functions in callbacks. Ideally we use arrow functions in place of all anonymous functions, though there doesn't seem to be a rule for this. This rule just flags callbacks, but it's a start. cc @chriszarate 

Wrong:

```
doThings( function() { ... } );
```

Right:

```
doThings( () => { ... } );
```