### PR TITLE
Relax peer dependencies for eslint-plugin-jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.10.0",
     "eslint-plugin-wpcalypso": "^4.0.1",
     "eslint-plugin-json": "^1.2.1 || ^2.0.0 || ^3.0.0",
-    "eslint-plugin-jest": "24.4.0"
+    "eslint-plugin-jest": "^24.4.0"
   },
   "devDependencies": {
     "@babel/core": "7.15.0",


### PR DESCRIPTION
Following the advice from [nodejs.org](https://nodejs.org/en/blog/npm/peer-dependencies/):
> One piece of advice: peer dependency requirements, unlike those for regular dependencies, should be lenient. You should not lock your peer dependencies down to specific patch versions. It would be really annoying if one Chai plugin peer-depended on Chai 1.4.1, while another depended on Chai 1.5.0, simply because the authors were lazy and didn't spend the time figuring out the actual minimum version of Chai they are compatible with.

this PR updates the required version of `eslint-plugin-jest` to `^24.4.0` from `24.4.0`.
