### PR TITLE
Publish as NPM package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+.babel*
+.circleci/
+__fixtures__/
+__tests__/

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# WordPress VIP ESLint config
+# WordPress VIP ESLint plugin
 
-ESLint plugin to provide WordPress VIP's (internal) JavaScript and TypeScript coding standards. It is designed to extend [`@wordpress/eslint-plugin`](https://github.com/WordPress/gutenberg/tree/trunk/packages/eslint-plugin), but allows you to choose which preset(s) you want to use.
+This is an ESLint plugin to provide WordPress VIP's (internal) JavaScript and TypeScript coding standards. It is designed to extend [`@wordpress/eslint-plugin`](https://github.com/WordPress/gutenberg/tree/trunk/packages/eslint-plugin), but allows you to choose which preset(s) you want to use.
 
 ## Installation
 
-Install `eslint` and `eslint-config-wpvip` to your project. Note that this package is not yet published to NPM, so you'll need to grab the latest commit SHA and use an alias.
+Install `eslint` and `@automattic/eslint-plugin-wpvip` to your project.
 
 ```sh
-npm install --save-dev eslint eslint-plugin-wpvip@github:Automattic/eslint-config-wpvip#[commit-sha]
+npm install --save-dev eslint @automattic/eslint-plugin-wpvip
 ```
 
 If your project uses TypeScript, make sure `typescript` is installed as well.
@@ -20,10 +20,10 @@ Create an `.eslintrc.json` file with your desired presets. Here is an example th
 {
 	"extends": [
 		"plugin:@wordpress/eslint-plugin/recommended",
-		"plugin:wpvip/base",
-		"plugin:wpvip/react",
-		"plugin:wpvip/testing",
-		"plugin:wpvip/typescript",
+		"plugin:@automattic/wpvip/base",
+		"plugin:@automattic/wpvip/react",
+		"plugin:@automattic/wpvip/testing",
+		"plugin:@automattic/wpvip/typescript",
 	]
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-wpvip",
-  "version": "0.0.1",
+  "version": "0.1.1-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automattic/eslint-plugin-wpvip",
-  "version": "0.1.0",
+  "version": "0.1.1-0",
   "description": "ESLint plugin for internal WordPress VIP projects",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,18 @@
 {
-  "name": "eslint-config-wpvip",
-  "version": "0.0.1",
-  "description": "ESLint configs to enforce VIP's (internal) JS coding standards",
+  "name": "@automattic/eslint-plugin-wpvip",
+  "version": "0.1.0",
+  "description": "ESLint plugin for internal WordPress VIP projects",
   "main": "index.js",
   "scripts": {
     "jest": "jest",
     "jest:update-snapshot": "jest --updateSnapshot",
     "lint": "eslint --ignore-pattern '__fixtures__' .",
+    "publish": "npx np --any-branch --branch=trunk --no-release-draft",
+    "publish:beta": "npm run publish -- --tag=beta",
     "test": "npm run lint && jest"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Published as [NPM package](https://www.npmjs.com/package/@automattic/eslint-plugin-wpvip) (using `beta` dist-tag, although it currently grabs `latest` as well since nothing has been pushed there yet).
- Name becomes `@automattic/eslint-plugin-wpvip` ("plugin" has become the preferred term in ESLint)
- Updates README

(I am not very opinionated about using `np` or some other NPM publish helper, so please feel free to suggest another. Except ... maybe not `publish-please` since that is abandonware. 😅)