### PR TITLE
Silence jsdoc/require-param for TypeScript files

### DIFF
--- a/__fixtures__/typescript/allowed.ts
+++ b/__fixtures__/typescript/allowed.ts
@@ -1,5 +1,18 @@
+/**
+ * This function adds two integers together.
+ */
 export function add( one: number, two: number, _three: number ): number {
 	return one + two;
+}
+
+/**
+ * This function subtracts two integers from one another.
+ *
+ * @param  one
+ * @param  two
+ */
+export function subtract( one: number, two: number ): number {
+	return one - two;
 }
 
 const things = {

--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -24,6 +24,7 @@ module.exports = {
 		{
 			files: [ '**/*.ts', '**/*.tsx' ],
 			parser: '@typescript-eslint/parser',
+			// Note that these rules only take effect in TypeScript files (.ts, .tsx).
 			rules: {
 				// Prefer the TypeScript versions of some rules.
 				'no-duplicate-imports': 'off',
@@ -31,7 +32,9 @@ module.exports = {
 				'no-shadow': 'off',
 				'@typescript-eslint/no-shadow': 'error',
 
-				// Don't require redundant JSDoc types in TypeScript files.
+				// Don't require redundant JSDoc parameter descriptions and types in
+				// TypeScript files.
+				'jsdoc/require-param': 'off',
 				'jsdoc/require-param-type': 'off',
 				'jsdoc/require-returns-type': 'off',
 			},


### PR DESCRIPTION
Since TypeScript annotations serve the same purpose as JSDoc annotations, do not require them in TypeScript files.
