### PR TITLE
Bump npm-publish action to v0.1.1

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,7 +18,7 @@ jobs:
     name: Publish to npm
     runs-on: ubuntu-latest
     steps:
-      - uses: Automattic/vip-actions/npm-publish@v0.1.0
+      - uses: Automattic/vip-actions/npm-publish@v0.1.1
         with:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           npm-version-type: ${{ inputs.npm-version-type }}


### PR DESCRIPTION
Includes a critical fix that was breaking the action.