### PR TITLE
Typescript: Allow empty classes with decorators.

### DIFF
--- a/__fixtures__/typescript.ts
+++ b/__fixtures__/typescript.ts
@@ -25,3 +25,13 @@ export function shadow() {
 export default {
 	things,
 };
+
+function someCoolDecorator(
+	totallyRadArgument,
+	value
+): typeof totallyRadArgument {
+	return totallyRadArgument;
+}
+
+@someCoolDecorator
+export class EmptyClass {}

--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -45,6 +45,15 @@ module.exports = {
 
 				// Handled by TS itself.
 				'no-unused-vars': 'off',
+
+				// Empty classes are allowed if they are accompanied by a decorator.
+				// This is common in frameworks such as Angular / nest.js.
+				'@typescript-eslint/no-extraneous-class': [
+					'warn',
+					{
+						allowWithDecorator: true,
+					},
+				],
 			},
 		},
 	],


### PR DESCRIPTION
This is a common pattern in nest.js / Angular, etc.