### PR TITLE
Prettier trailingComma: 'es5'

### DIFF
--- a/__tests__/check-fixtures.js
+++ b/__tests__/check-fixtures.js
@@ -10,7 +10,7 @@ async function getLintMessages( fixture ) {
 	} );
 
 	const [ { messages } ] = await eslint.lintFiles(
-		path.resolve( ...rootPaths, '__fixtures__', fixture ),
+		path.resolve( ...rootPaths, '__fixtures__', fixture )
 	);
 
 	return messages;

--- a/prettierrc.js
+++ b/prettierrc.js
@@ -6,6 +6,6 @@ module.exports = {
 	printWidth: 100,
 	semi: true,
 	singleQuote: true,
-	trailingComma: 'all',
+	trailingComma: 'es5',
 	useTabs: true,
 };

--- a/rules/no-unguarded-get-range-at.js
+++ b/rules/no-unguarded-get-range-at.js
@@ -11,7 +11,7 @@ module.exports = {
 	create( context ) {
 		return {
 			'CallExpression[callee.object.callee.property.name="getSelection"][callee.property.name="getRangeAt"]'(
-				node,
+				node
 			) {
 				context.report( {
 					node,


### PR DESCRIPTION
We don't want trailing commas in function params, etc.

https://prettier.io/docs/en/options.html#trailing-commas