### PR TITLE
Add eslint-plugin-promise plugin

### DIFF
--- a/configs/javascript.js
+++ b/configs/javascript.js
@@ -24,7 +24,7 @@ module.exports = {
 	/**
 	 * Note: We must explicitly add this plugin to use our custom rules.
 	 */
-	plugins: [ '@automattic/wpvip', 'import' ],
+	plugins: [ '@automattic/wpvip', 'import', 'promise' ],
 
 	/**
 	 * Please include a short description of the rule. For rules that downgrade or
@@ -202,6 +202,22 @@ module.exports = {
 		],
 
 		'wrap-iife': [ 'error', 'any' ],
+
+		'promise/always-return': 'off',
+		'promise/avoid-new': 'off',
+		'promise/catch-or-return': 'off',
+		'promise/no-callback-in-promise': 'warn',
+		'promise/no-multiple-resolved': 'error',
+		'promise/no-native': 'off',
+		'promise/no-nesting': 'warn',
+		'promise/no-new-statics': 'error',
+		'promise/no-promise-in-callback': 'warn',
+		'promise/no-return-in-finally': 'error',
+		'promise/no-return-wrap': 'error',
+		'promise/param-names': 'error',
+		'promise/prefer-await-to-callbacks': 'off',
+		'promise/prefer-await-to-then': 'off',
+		'promise/valid-params': 'warn',
 	},
 
 	settings: {

--- a/configs/javascript.js
+++ b/configs/javascript.js
@@ -217,7 +217,7 @@ module.exports = {
 		'promise/param-names': 'error',
 		'promise/prefer-await-to-callbacks': 'off',
 		'promise/prefer-await-to-then': 'off',
-		'promise/valid-params': 'warn',
+		'promise/valid-params': 'error',
 	},
 
 	settings: {

--- a/configs/weak-javascript.js
+++ b/configs/weak-javascript.js
@@ -58,6 +58,7 @@ module.exports = {
 				'promise/no-return-in-finally': 'warn',
 				'promise/no-return-wrap': 'warn',
 				'promise/param-names': 'warn',
+				'promise/valid-params': 'warn',
 			},
 		},
 	],

--- a/configs/weak-javascript.js
+++ b/configs/weak-javascript.js
@@ -52,6 +52,12 @@ module.exports = {
 				'one-var': 'warn',
 
 				radix: 'warn',
+
+				'promise/no-multiple-resolved': 'warn',
+				'promise/no-new-statics': 'warn',
+				'promise/no-return-in-finally': 'warn',
+				'promise/no-return-wrap': 'warn',
+				'promise/param-names': 'warn',
 			},
 		},
 	],

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "eslint-plugin-json": "3.1.0",
         "eslint-plugin-jsx-a11y": "6.7.1",
         "eslint-plugin-prettier": "4.2.1",
+        "eslint-plugin-promise": "6.1.1",
         "eslint-plugin-react": "7.32.2",
         "eslint-plugin-react-hooks": "4.6.0",
         "eslint-plugin-security": "1.7.1",
@@ -2920,6 +2921,17 @@
         "eslint-config-prettier": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-promise": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.1.1.tgz",
+      "integrity": "sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/eslint-plugin-react": {
@@ -8619,6 +8631,12 @@
       "requires": {
         "prettier-linter-helpers": "^1.0.0"
       }
+    },
+    "eslint-plugin-promise": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.1.1.tgz",
+      "integrity": "sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==",
+      "requires": {}
     },
     "eslint-plugin-react": {
       "version": "7.32.2",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eslint-plugin-json": "3.1.0",
     "eslint-plugin-jsx-a11y": "6.7.1",
     "eslint-plugin-prettier": "4.2.1",
+    "eslint-plugin-promise": "6.1.1",
     "eslint-plugin-react": "7.32.2",
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-security": "1.7.1",


### PR DESCRIPTION
This PR adds `eslint-plugin-promise-plugin` to the `@automattic/wpvip/javascript` configuration.

The reason is that the SonarCloud scan shows that most of the issues in the `@automattic/vip-cli` codebase come from misusing promises.

For example:

```js
try {
    // ...

    // Token.setUuid() is an async method (returns a Promise)
    Token.setUuid( vipUserId );
} catch ( err ) {
    // ...
}
```

In the code above, because `setUuid()` is not awaited, errors thrown in it will not be caught by the `catch` statement. Such bugs can lead to unhandled promise rejections.

The idea behind this PR‌ is to help catch such bugs early.

Descriptions of the rules: https://github.com/eslint-community/eslint-plugin-promise/blob/main/README.md

As a starting point, I have set the severity of the rules to the values I use myself in my own projects.
