### PR TITLE
Get first iterator value instead of last

### DIFF
--- a/utils/is-package-installed.js
+++ b/utils/is-package-installed.js
@@ -1,8 +1,7 @@
 const debugLog = require( './debug-log' );
 const findPackageJson = require( 'find-package-json' );
 
-const packages = [ ...findPackageJson( __dirname ) ];
-const parent = packages.pop() || {};
+const parent = findPackageJson( __dirname ).next()?.value || {};
 
 debugLog( `Found package.json: ${ parent.__path || 'none' }` );
 


### PR DESCRIPTION
The [`find-package-json`](https://www.npmjs.com/package/find-package-json) lib returns an iterator that will ascend up the directory tree. Therefore we want the first value returned by the iterator, not the last.