### PR TITLE
Improve tree traversal to find package root

### DIFF
--- a/utils/is-package-installed.js
+++ b/utils/is-package-installed.js
@@ -1,8 +1,23 @@
 const debugLog = require( './debug-log' );
 const findPackageJson = require( 'find-package-json' );
 
+// Get a list of all package.json files in the current directory tree, ascending
+// up the tree from the current directory. Note that this code behaves differently
+// when it is installed as a package vs. when we are linting the code in this repo.
+//
+// When installed as a package, the current directory is inside node_modules and is
+// not the "package root" as we are thinking about it. In this case, we need to ignore
+// all package.json files that are inside node_modules directories.
+//
+// When we are linting the code in this repo, the current directory is not inside
+// node_modules and the first found "package.json" is the "package root."
+//
+// This problem is basically impossible to solve for all edge cases (like someone who
+// runs `npm run lint` from inside "node_modules") but this code should work for
+// most cases.
 const packages = [ ...findPackageJson( __dirname ) ];
-const parent = packages[ 1 ] || {};
+const parent =
+	packages.find( pkg => ! pkg.__path.includes( '/node_modules/' ) ) || packages.pop() || {};
 
 debugLog( `Found package.json: ${ parent.__path || 'none' }` );
 

--- a/utils/is-package-installed.js
+++ b/utils/is-package-installed.js
@@ -1,7 +1,8 @@
 const debugLog = require( './debug-log' );
 const findPackageJson = require( 'find-package-json' );
 
-const parent = findPackageJson( __dirname ).next()?.value || {};
+const packages = [ ...findPackageJson( __dirname ) ];
+const parent = packages[ 1 ] || {};
 
 debugLog( `Found package.json: ${ parent.__path || 'none' }` );
 


### PR DESCRIPTION
Correctly account for tree traversal in most cases.