### PR TITLE
Update the base to properly check Typescript errors, and prettier and editorconfig settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,5 +7,8 @@ indent_style = tab
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.json,*.yaml,*.yml]
+[{*.json,*.yaml,*.yml}]
 indent_style = space
+
+[{package.json,tsconfig.json,tsconfig.*.json}]
+tab_width = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -11,4 +11,4 @@ trim_trailing_whitespace = true
 indent_style = space
 
 [{package.json,tsconfig.json,tsconfig.*.json}]
-tab_width = 2
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,4 @@ trim_trailing_whitespace = true
 
 [{*.json,*.yaml,*.yml}]
 indent_style = space
-
-[{package.json,tsconfig.json,tsconfig.*.json}]
 indent_size = 2

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,0 @@
-package.json
-package-lock.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,2 @@
 package.json
 package-lock.json
-__fixtures__/javascript.js
-__fixtures__/typescript.ts

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+package.json
+package-lock.json
+__fixtures__/javascript.js
+__fixtures__/typescript.ts

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "ESLint plugin for internal WordPress VIP projects",
   "main": "index.js",
   "scripts": {
-    "check-types": "tsc __tests__/**/*.ts",
+    "check-types": "tsc -p tsconfig.check.json",
     "cmd:format": "prettier --ignore-path .gitignore '**/*.(js|json|jsx|md|ts|tsx|yml|yaml)'",
     "cmd:jest": "npm run link-plugin && jest",
     "cmd:lint": "npm run link-plugin && eslint --ext 'js,jsx,ts,tsx'",

--- a/tsconfig.check.json
+++ b/tsconfig.check.json
@@ -1,5 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "include": [ "**/*.ts" ],
   "exclude": [ "__fixtures__" ]
 }

--- a/tsconfig.check.json
+++ b/tsconfig.check.json
@@ -1,5 +1,5 @@
 {
-	"extends": "./tsconfig.json",
+  "extends": "./tsconfig.json",
   "include": [ "**/*.ts" ],
   "exclude": [ "__fixtures__" ]
 }

--- a/tsconfig.check.json
+++ b/tsconfig.check.json
@@ -1,0 +1,5 @@
+{
+	"extends": "./tsconfig.json",
+  "include": [ "**/*.ts" ],
+  "exclude": [ "__fixtures__" ]
+}


### PR DESCRIPTION
## Description

Due to this infamous TypeScript bug, https://github.com/microsoft/TypeScript/issues/27379, when passing a file to `tsc`, `tsc` will then proceed to ignore `tsconfig.json` completely. There's also no way to pass a config file, and a specific file at the same time.

So if we want to do type-checking, we must either call `tsc` or `tsc -p <config-file>` on their own without extra parameters.

Alternatively we could pass in all individual settings parameter to `tsc` but that seems unwieldy.

So this PR fixes that by creating a `tsconfig.check.json` that inherits the base `tsconfig.json` and specifies what files do we want to typecheck.

~~Also added `.prettierignore` to prevent ourselves from formatting the fixture files~~ Can't add fixtures to prettierignore because eslint respects prettierignore too, and the editorconfig to reflect our tsconfig.json that currently uses spaces.

## How to test?

1. Don't pull this PR yet. Pull `trunk` instead.
2. Apply this patch:
```patch
Subject: [PATCH] Demonstrate implicit any not being caught by type-checking
---
Index: __tests__/rules/no-async-foreach.ts
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/__tests__/rules/no-async-foreach.ts b/__tests__/rules/no-async-foreach.ts
--- a/__tests__/rules/no-async-foreach.ts	(revision e611a8f6dc44e374b23d12edb168c64b8063efe8)
+++ b/__tests__/rules/no-async-foreach.ts	(date 1692781091695)
@@ -5,6 +5,10 @@
 const parserOptions: Linter.ParserOptions = { ecmaVersion: 8 };
 const errors = [ { message: 'Avoid passing an async function to Array.prototype.forEach' } ];
 
+const implicitAny = ( heresYourImplicit ) => {
+	return heresYourImplicit;
+}
+
 describe( 'no-async-foreach', () => {
 	ruleTester.run( 'no-async-foreach', rule, {
 		valid: [
```
3. Run `npm run check-types`. Implicit any gets ignored! Javascript file got generated as well.
4. Pull this PR, run the above patch again if you've accidentally undone it.
5. Run `npm run check-types` again. You should get an error about implicit any.