### PR TITLE
Add limitation for wp-prettier v3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,10 @@ Note that the order of configs can matter, since they can contain overrides. It 
 Install [WP Prettier](https://github.com/Automattic/wp-prettier) to benefit from additional formatting rules:
 
 ```sh
-npm i --save-dev --save-exact "prettier@npm:wp-prettier@latest"
+npm i --save-dev --save-exact "prettier@npm:wp-prettier@2.8.5"
 ```
+
+Ensure that wp-prettier v3.0 and is above is not installed as that isn't currently supported.
 
 This repo also provides a Prettier config, which you can use with the following `.prettierrc`:
 

--- a/README.md
+++ b/README.md
@@ -72,13 +72,11 @@ Note that the order of configs can matter, since they can contain overrides. It 
 
 ### Prettier
 
-Install [WP Prettier](https://github.com/Automattic/wp-prettier) to benefit from additional formatting rules:
+Install [WP Prettier](https://github.com/Automattic/wp-prettier) v2.x to benefit from additional formatting rules:
 
 ```sh
 npm i --save-dev --save-exact "prettier@npm:wp-prettier@2.8.5"
 ```
-
-Ensure that wp-prettier v3.0 and is above is not installed as that isn't currently supported.
 
 This repo also provides a Prettier config, which you can use with the following `.prettierrc`:
 


### PR DESCRIPTION
**Description**

At the moment, wp-prettier v3.0 causes the following problem to occur:

```
TypeError: prettier.resolveConfig.sync is not a function
Occurred while linting <redacted path to the code>/.eslintrc.js:1
Rule: "prettier/prettier"
    at Program (<redacted path to the code>/node_modules/eslint-plugin-prettier/eslint-plugin-prettier.js:138:40)
```

This is because of [this PR](https://github.com/prettier/prettier/pull/12788) that removed supported for that function entirely in prettier. There have been updates made to `eslint-plugin-prettier` that should resolve it, but there could be additional dependencies that need updating/fixing as well. That might take some time to do in order to support v3.0 of wp-prettier. 

In the meantime, I have made this small change to the README to ensure someone else doesn't run into this like me.

I'll try and spend some time in fixing this, this week or the next.

**Replicating instructions**

Follow the readme, including installing the latest wp-prettier version and lint your code. You will run into the same problem as me.