### PR TITLE
Add @typescript-eslint/explicit-member-accessibility

### DIFF
--- a/__fixtures__/javascript.js
+++ b/__fixtures__/javascript.js
@@ -53,3 +53,12 @@ export function base64encode( str ) {
 }
 
 export const constantBinary = x() || x() !== {};
+
+export class CoolClass {
+	// JavaScript doesn't have accessibility modifiers, so we expect this to be allowed.
+	secret = 'shhh';
+
+	implicitlyPublicMethod() {
+		return 'hi';
+	}
+}

--- a/__fixtures__/typescript.ts
+++ b/__fixtures__/typescript.ts
@@ -34,7 +34,19 @@ function someCoolDecorator( totallyRadArgument, _value ): typeof totallyRadArgum
 }
 
 @someCoolDecorator
-export class EmptyClass {}
+export class CoolClass {
+	secret: string;
+
+	constructor() {
+		// Constructors are exempt from explicit-member-accessibility rules, but
+		// properties are not.
+		this.secret = 'shhh';
+	}
+
+	implicitlyPublicMethod() {
+		return 'hi';
+	}
+}
 
 export function base64encode( str: string ): string {
 	return Buffer.from( str ).toString( 'base64' );

--- a/__tests__/__snapshots__/check-fixtures.js.snap
+++ b/__tests__/__snapshots__/check-fixtures.js.snap
@@ -454,5 +454,115 @@ import { unusedEs6Import } from './stub/unusedEs6Import';
     "ruleId": "@typescript-eslint/no-shadow",
     "severity": 2,
   },
+  {
+    "column": 2,
+    "endColumn": 17,
+    "endLine": 38,
+    "line": 38,
+    "message": "Missing accessibility modifier on class property secret.",
+    "messageId": "missingAccessibility",
+    "nodeType": "PropertyDefinition",
+    "ruleId": "@typescript-eslint/explicit-member-accessibility",
+    "severity": 2,
+    "suggestions": [
+      {
+        "data": {
+          "type": "public",
+        },
+        "desc": "Add 'public' accessibility modifier",
+        "fix": {
+          "range": [
+            675,
+            675,
+          ],
+          "text": "public ",
+        },
+        "messageId": "addExplicitAccessibility",
+      },
+      {
+        "data": {
+          "type": "private",
+        },
+        "desc": "Add 'private' accessibility modifier",
+        "fix": {
+          "range": [
+            675,
+            675,
+          ],
+          "text": "private ",
+        },
+        "messageId": "addExplicitAccessibility",
+      },
+      {
+        "data": {
+          "type": "protected",
+        },
+        "desc": "Add 'protected' accessibility modifier",
+        "fix": {
+          "range": [
+            675,
+            675,
+          ],
+          "text": "protected ",
+        },
+        "messageId": "addExplicitAccessibility",
+      },
+    ],
+  },
+  {
+    "column": 2,
+    "endColumn": 3,
+    "endLine": 48,
+    "line": 46,
+    "message": "Missing accessibility modifier on method definition implicitlyPublicMethod.",
+    "messageId": "missingAccessibility",
+    "nodeType": "MethodDefinition",
+    "ruleId": "@typescript-eslint/explicit-member-accessibility",
+    "severity": 2,
+    "suggestions": [
+      {
+        "data": {
+          "type": "public",
+        },
+        "desc": "Add 'public' accessibility modifier",
+        "fix": {
+          "range": [
+            838,
+            838,
+          ],
+          "text": "public ",
+        },
+        "messageId": "addExplicitAccessibility",
+      },
+      {
+        "data": {
+          "type": "private",
+        },
+        "desc": "Add 'private' accessibility modifier",
+        "fix": {
+          "range": [
+            838,
+            838,
+          ],
+          "text": "private ",
+        },
+        "messageId": "addExplicitAccessibility",
+      },
+      {
+        "data": {
+          "type": "protected",
+        },
+        "desc": "Add 'protected' accessibility modifier",
+        "fix": {
+          "range": [
+            838,
+            838,
+          ],
+          "text": "protected ",
+        },
+        "messageId": "addExplicitAccessibility",
+      },
+    ],
+  },
 ]
 `;

--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -23,6 +23,17 @@ module.exports = {
 			},
 
 			rules: {
+				// Require explicity visibility for class methods and properties to avoid
+				// implicit public access. Allow constructors to be implicitly public.
+				'@typescript-eslint/explicit-member-accessibility': [
+					'error',
+					{
+						overrides: {
+							constructors: 'off',
+						},
+					},
+				],
+
 				// TypeScript `any` type must not be used. This is a warning in the base
 				// config, and is elevated to an error here.
 				'@typescript-eslint/no-explicit-any': 'error',


### PR DESCRIPTION
Add `@typescript-eslint/explicit-member-accessibility` rule to enforce the use of accessibility keywords like `public`, `private`, or `protected`. These keywords are critical to preventing the unintended exposure of private implementation details.

https://typescript-eslint.io/rules/explicit-member-accessibility/

```ts
// Good
class MyClass {
  private secretKey = 'foo';

  constructor( private anotherSecretKey: string ) {}

  private updateDBRecord() {}

  public createResource() {
    // do some validation
    this.updateDBRecord();
  }
}

// Bad
class MyClass {
  secretKey = 'foo';

  constructor( anotherSecretKey: string ) {
    this.anotherSecretKey = anotherSecretKey;
  }

  updateDBRecord() {}

  createResource() {
    // do some validation
    this.updateDBRecord();
  }
}
```