### PR TITLE
Disable no-console for CLI config

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,12 +100,18 @@ module.exports = {
 };
 ```
 
-If your project is not a CLI tool but calls `console` or `process` methods occasionally, you probably don't need this config. Instead, disable those rules only where necessary and include an explanation:
+If your project is not a CLI tool but calls `process` methods occasionally, you probably don't need this config. Instead, disable those rules only where necessary and include an explanation:
 
 ```js
 // Intentionally exiting because we have observed an unrecoverable error.
 // eslint-disable-next-line no-process-exit
 process.exit( 1 );
+```
+
+Note that `console.log` is still forbidden ([see here for an explanation](https://github.com/Automattic/eslint-config-wpvip/pull/198#issuecomment-2015322062)). If you're writing one-off Node scripts, you can disable the rule per file:
+
+```js
+/* eslint-disable no-console */
 ```
 
 ## JSDoc

--- a/configs/cli.js
+++ b/configs/cli.js
@@ -9,8 +9,5 @@ module.exports = {
 
 		// Process.exit is used in CLI context to stop execution.
 		'no-process-exit': 'off',
-
-		// console.log is used all the time in the CLI context.
-		'no-console': 'off',
 	},
 };

--- a/configs/cli.js
+++ b/configs/cli.js
@@ -9,5 +9,8 @@ module.exports = {
 
 		// Process.exit is used in CLI context to stop execution.
 		'no-process-exit': 'off',
+
+		// console.log is used all the time in the CLI context.
+		'no-console': 'off',
 	},
 };


### PR DESCRIPTION
Edit: I've updated this to just clarify the readme.

I used the CLI config in a different repo (see https://github.com/Automattic/vip-go-utility-scripts/pull/477), but was surprised that using `console.log` still showed warnings. (The readme also implies that this rule is disabled here: https://github.com/Automattic/eslint-config-wpvip?tab=readme-ov-file#cli)

Any objections to disabling the `no-console` rule for the CLI preset?