### PR TITLE
feat: add ESM support

### DIFF
--- a/configs/javascript.js
+++ b/configs/javascript.js
@@ -254,7 +254,7 @@ module.exports = {
 	settings: {
 		'import/resolver': {
 			node: {
-				extensions: [ '.js', '.jsx', '.ts', '.tsx' ],
+				extensions: [ '.js', '.jsx', '.ts', '.tsx', '.cjs', '.mjs', '.cts', '.mts' ],
 			},
 			typescript: 'eslint-import-resolver-typescript',
 		},

--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -4,7 +4,7 @@
  */
 
 module.exports = {
-	ignorePatterns: [ '**/*.d.ts' ],
+	ignorePatterns: [ '**/*.d.ts', '**/*.d.cts', '**/*.d.mts' ],
 
 	overrides: [
 		{
@@ -14,7 +14,7 @@ module.exports = {
 				'plugin:@typescript-eslint/strict',
 			],
 
-			files: [ '**/*.ts', '**/*.tsx' ],
+			files: [ '**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts' ],
 
 			parser: '@typescript-eslint/parser',
 

--- a/configs/weak-typescript.js
+++ b/configs/weak-typescript.js
@@ -7,7 +7,7 @@
 module.exports = {
 	overrides: [
 		{
-			files: [ '**/*.ts', '**/*.tsx' ],
+			files: [ '**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts' ],
 
 			/**
 			 * Downgrade rules from the base preset to "warn". Do not disable rules (set


### PR DESCRIPTION
Better support ESM by adding CommonJS and ESM extensions to the resolver config and TypeScript overrides.

To test: create a TS project with `{ "type": "module" }` and create `index.mts`. ESLint should not ignore the `.mts` file.
