### PR TITLE
fix(typescript): use `@typescript-eslint/dot-notation` instead of `dot-notation`

### DIFF
--- a/configs/recommended.js
+++ b/configs/recommended.js
@@ -5,11 +5,11 @@ const config = {
 	extends: [ require.resolve( './javascript' ) ],
 };
 
+config.extends.push( require.resolve( './formatting' ) );
+
 if ( isPackageInstalled( 'typescript' ) ) {
 	config.extends.push( require.resolve( './typescript' ) );
 }
-
-config.extends.push( require.resolve( './formatting' ) );
 
 if ( isPackageInstalled( 'jest' ) ) {
 	config.extends.push( require.resolve( './testing' ) );

--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -53,6 +53,9 @@ module.exports = {
 				'@typescript-eslint/no-shadow': 'error',
 				'import/no-duplicates': 'error',
 
+				'dot-notation': 'off',
+				'@typescript-eslint/dot-notation': [ 'error', { allowKeywords: true } ],
+
 				// Empty classes are allowed if they are accompanied by a decorator.
 				// This is common in frameworks such as Angular / nest.js.
 				'@typescript-eslint/no-extraneous-class': [


### PR DESCRIPTION
ESLint's `dot-notation` rule does not consider TypeScript's `noPropertyAccessFromIndexSignature` configuration option.

This PR replaces `dot-notation` with `@typescript-eslint/dot-notation` and moves the `formatting` config in front of the `typescript` config because `formatting` reenables `dot-notation`.
