### PR TITLE
Use `jest/unbound-method` in test files

### DIFF
--- a/__fixtures__/typescript.test.ts
+++ b/__fixtures__/typescript.test.ts
@@ -1,0 +1,17 @@
+class MyClass {
+	public doStuff() {
+		return 'real';
+	}
+}
+
+const myClass = new MyClass();
+myClass.doStuff = jest.fn( () => 'fake' );
+
+describe( 'TypeScript test', () => {
+	it( 'should allow unbound mocks to be called and inspected', () => {
+		const value = myClass.doStuff();
+
+		expect( myClass.doStuff ).toHaveBeenCalledTimes( 1 );
+		expect( value ).toEqual( 'fake' );
+	} );
+} );

--- a/__tests__/__snapshots__/check-fixtures.js.snap
+++ b/__tests__/__snapshots__/check-fixtures.js.snap
@@ -258,6 +258,8 @@ exports[`linting javascript-missing-eol.js fixture matches snapshot 1`] = `
 ]
 `;
 
+exports[`linting typescript.test.ts fixture matches snapshot 1`] = `[]`;
+
 exports[`linting typescript.ts fixture matches snapshot 1`] = `
 [
   {

--- a/__tests__/check-fixtures.js
+++ b/__tests__/check-fixtures.js
@@ -17,10 +17,12 @@ async function getLintMessages( fixture ) {
 }
 
 describe( 'linting', () => {
-	it.each( [ 'javascript.js', 'javascript-missing-eol.js', 'typescript.ts' ] )(
-		'%s fixture matches snapshot',
-		async fixture => {
-			expect( await getLintMessages( fixture ) ).toMatchSnapshot();
-		}
-	);
+	it.each( [
+		'javascript.js',
+		'javascript-missing-eol.js',
+		'typescript.ts',
+		'typescript.test.ts',
+	] )( '%s fixture matches snapshot', async fixture => {
+		expect( await getLintMessages( fixture ) ).toMatchSnapshot();
+	} );
 } );

--- a/configs/testing.js
+++ b/configs/testing.js
@@ -1,10 +1,12 @@
+const isPackageInstalled = require( '../utils/is-package-installed' );
+
 /**
  * Based on:
  * - https://github.com/WordPress/gutenberg/blob/%40wordpress/eslint-plugin%4014.1.0/packages/eslint-plugin/configs/test-unit.js
  * - https://github.com/WordPress/gutenberg/blob/%40wordpress/eslint-plugin%4014.1.0/packages/eslint-plugin/configs/test-e2e.js
  */
 
-module.exports = {
+const config = {
 	extends: [ 'plugin:jest/recommended' ],
 
 	env: {
@@ -13,3 +15,19 @@ module.exports = {
 
 	plugins: [ 'jest' ],
 };
+
+if ( isPackageInstalled( 'typescript' ) ) {
+	// Add an override for TypeScript's overzealous unbound-method rule that allows
+	// Jest mocks to be inspected without being bound to a variable.
+	config.overrides = [
+		{
+			files: [ '__tests__/**/*.ts', '**/*.test.ts', '**/*.spec.ts' ],
+			rules: {
+				'@typescript-eslint/unbound-method': 'off',
+				'jest/unbound-method': 'error',
+			},
+		},
+	];
+}
+
+module.exports = config;


### PR DESCRIPTION
This ports over a useful override from GOOP:
https://github.com/Automattic/vip-go-api/blob/5db9c92459bd1efffd2c000cdaab6648fa1daa5e/.eslintrc.js#L28-L34