### PR TITLE
Remove rules that dangerously allow known type errors

### DIFF
--- a/configs/weak-typescript.js
+++ b/configs/weak-typescript.js
@@ -2,7 +2,8 @@
  * "Weak" TypeScript rules
  * ==========================
  * These rules are intended to extend the base `typescript` rules and will help
- * you migrate an existing project to TypeScript.
+ * you migrate an existing project to TypeScript. They are primarily focused on
+ * allowing relaxed or omitted types.
  */
 module.exports = {
 	overrides: [
@@ -16,10 +17,6 @@ module.exports = {
 			rules: {
 				'@typescript-eslint/no-explicit-any': 'warn',
 
-				'@typescript-eslint/no-floating-promises': 'warn',
-
-				'@typescript-eslint/no-misused-promises': 'warn',
-
 				'@typescript-eslint/no-unsafe-argument': 'warn',
 
 				'@typescript-eslint/no-unsafe-assignment': 'warn',
@@ -29,12 +26,6 @@ module.exports = {
 				'@typescript-eslint/no-unsafe-member-access': 'warn',
 
 				'@typescript-eslint/no-unsafe-return': 'warn',
-
-				'@typescript-eslint/require-await': 'warn',
-
-				'@typescript-eslint/restrict-plus-operands': 'warn',
-
-				'@typescript-eslint/restrict-template-expressions': 'warn',
 
 				'@typescript-eslint/unbound-method': 'warn',
 


### PR DESCRIPTION
There were a few rules in our `weak-typescript` preset that allow dangerous type errors. For example, this is a dangerous bug that is preventable with `@typescript-eslint/no-misused-promises`:

```ts
const allowDangerousAction = functionThatReturnsPromise();

if ( allowDangerousAction ) {
  // always true because promise is not awaited!
}
```

The goal of this "weak" preset is to allow code to migrate to TypeScript without exhaustively supplying types. This PR removes relaxations that aren't directly focused on that goal. Migration may be painful but provides real value.