### PR TITLE
fix(typescript): allow for `this` as a parameter

### DIFF
--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -100,6 +100,9 @@ module.exports = [
 
 			'default-param-last': 'off',
 			'@typescript-eslint/default-param-last': 'error',
+
+			// `this: void` is useful for certain patterns, such as in event handlers or bound methods.
+			'@typescript-eslint/no-invalid-void-type': [ 'error', { allowAsThisParameter: true } ],
 		},
 	},
 ];


### PR DESCRIPTION
This pull request makes a small but important update to the TypeScript ESLint configuration. It enables the `@typescript-eslint/no-invalid-void-type` rule with an option to allow `void` as a `this` parameter, which is helpful for specific patterns like event handlers or bound methods. We use this pattern in CCM.

- Added `{ allowAsThisParameter: true }` to the `@typescript-eslint/no-invalid-void-type` rule to the ESLint configuration in `configs/typescript.js`, ensuring better type safety while supporting common TypeScript patterns.

Ref: https://typescript-eslint.io/rules/no-invalid-void-type/#allowasthisparameter, https://www.typescriptlang.org/docs/handbook/functions.html#this-parameters-in-callbacks