### PR TITLE
feat: implement strategy for optional peer deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,15 @@ Install `eslint` and `@automattic/eslint-plugin-wpvip` to your project.
 npm install --save-dev eslint @automattic/eslint-plugin-wpvip
 ```
 
+Optional integrations are auto-detected when your project also installs `typescript`, `jest`, `react`, or `prettier`. These packages are declared as optional peer dependencies so consumers can opt in to the stacks they actually use.
+
 ## Contributing
 
 See [CONTRIBUTING.md](https://github.com/Automattic/eslint-config-wpvip/blob/trunk/CONTRIBUTING.md) for details on development, testing, publishing, etc.
 
 ## Configuration
 
-Create an `.eslintrc.js` file. **Note:** The `init` file allows you to avoid installing peer dependencies (available from `v0.5.0`).
+Create an `.eslintrc.js` file. If you use the `recommended` preset, you can preload the optional integrations with `init`.
 
 ```js
 require( '@automattic/eslint-plugin-wpvip/init' );
@@ -28,6 +30,8 @@ module.exports = {
 ```
 
 And that's it! It works automatically with most Babel and TypeScript projects. Code editors that are configured to work with ESLint will automatically pick up the rules and flag any errors or warnings.
+
+If your project uses only JavaScript, you do not need to install the optional peers. If you use the modular `typescript`, `testing`, `react`, or `prettier` configs directly, install the corresponding package in your project first.
 
 You may also wish to define an `.eslintignore` file if there are files or paths that you do not want to lint.
 
@@ -59,8 +63,8 @@ Of course, this recommended config may not be ideal for every project, so feel f
 module.exports = {
 	extends: [
 		'plugin:@automattic/wpvip/javascript',
-		'plugin:@automattic/wpvip/typescript', // when "typescript" is installed
 		'plugin:@automattic/wpvip/formatting',
+		'plugin:@automattic/wpvip/typescript', // when "typescript" is installed
 		'plugin:@automattic/wpvip/testing', // when "jest" is installed
 		'plugin:@automattic/wpvip/react', // when "react" is installed
 		'plugin:@automattic/wpvip/prettier', // when "prettier" is installed

--- a/__tests__/is-package-installed.js
+++ b/__tests__/is-package-installed.js
@@ -1,0 +1,48 @@
+jest.mock( '../utils/debug-log', () => jest.fn() );
+
+function loadIsPackageInstalledWith( packageJson ) {
+	jest.resetModules();
+
+	jest.doMock( 'find-package-json', () => () => [ packageJson ][ Symbol.iterator ]() );
+
+	return require( '../utils/is-package-installed' );
+}
+
+describe( 'isPackageInstalled', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'returns true for dependencies', () => {
+		const isPackageInstalled = loadIsPackageInstalledWith( {
+			__path: '/project/package.json',
+			dependencies: {
+				react: '^19.0.0',
+			},
+		} );
+
+		expect( isPackageInstalled( 'react' ) ).toBe( true );
+	} );
+
+	it( 'returns true for devDependencies', () => {
+		const isPackageInstalled = loadIsPackageInstalledWith( {
+			__path: '/project/package.json',
+			devDependencies: {
+				typescript: '^6.0.0',
+			},
+		} );
+
+		expect( isPackageInstalled( 'typescript' ) ).toBe( true );
+	} );
+
+	it( 'returns false for peerDependencies without an installed dependency entry', () => {
+		const isPackageInstalled = loadIsPackageInstalledWith( {
+			__path: '/project/package.json',
+			peerDependencies: {
+				typescript: '^6.0.0',
+			},
+		} );
+
+		expect( isPackageInstalled( 'typescript' ) ).toBe( false );
+	} );
+} );

--- a/__tests__/load-optional-config.js
+++ b/__tests__/load-optional-config.js
@@ -28,7 +28,7 @@ describe( 'loadOptionalConfig', () => {
 	} );
 
 	it( 'skips missing optional modules', () => {
-		const error = new Error( 'Cannot find module prettier' );
+		const error = new Error( "Cannot find module 'prettier'" );
 		error.code = 'MODULE_NOT_FOUND';
 
 		isPackageInstalled.mockReturnValue( true );
@@ -52,5 +52,33 @@ describe( 'loadOptionalConfig', () => {
 				throw error;
 			} )
 		).toThrow( error );
+	} );
+
+	it( 'rethrows MODULE_NOT_FOUND for unrelated modules', () => {
+		const error = new Error( "Cannot find module 'some-other-lib'" );
+		error.code = 'MODULE_NOT_FOUND';
+
+		isPackageInstalled.mockReturnValue( true );
+
+		expect( () =>
+			loadOptionalConfig( 'prettier', () => {
+				throw error;
+			} )
+		).toThrow( error );
+	} );
+
+	it( 'swallows MODULE_NOT_FOUND for subpaths of the optional peer', () => {
+		const error = new Error( "Cannot find module 'react/lib/something'" );
+		error.code = 'MODULE_NOT_FOUND';
+
+		isPackageInstalled.mockReturnValue( true );
+
+		expect(
+			loadOptionalConfig( 'react', () => {
+				throw error;
+			} )
+		).toEqual( [] );
+
+		expect( debugLog ).toHaveBeenCalledWith( expect.stringContaining( 'react' ) );
 	} );
 } );

--- a/__tests__/load-optional-config.js
+++ b/__tests__/load-optional-config.js
@@ -1,0 +1,56 @@
+jest.mock( '../utils/debug-log', () => jest.fn() );
+jest.mock( '../utils/is-package-installed', () => jest.fn() );
+
+const debugLog = require( '../utils/debug-log' );
+const isPackageInstalled = require( '../utils/is-package-installed' );
+const loadOptionalConfig = require( '../utils/load-optional-config' );
+
+describe( 'loadOptionalConfig', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'skips loading when the package is not installed', () => {
+		const loadConfig = jest.fn();
+
+		isPackageInstalled.mockReturnValue( false );
+
+		expect( loadOptionalConfig( 'react', loadConfig ) ).toEqual( [] );
+		expect( loadConfig ).not.toHaveBeenCalled();
+	} );
+
+	it( 'loads the config when the package is installed', () => {
+		const config = [ { name: 'react' } ];
+
+		isPackageInstalled.mockReturnValue( true );
+
+		expect( loadOptionalConfig( 'react', () => config ) ).toBe( config );
+	} );
+
+	it( 'skips missing optional modules', () => {
+		const error = new Error( 'Cannot find module prettier' );
+		error.code = 'MODULE_NOT_FOUND';
+
+		isPackageInstalled.mockReturnValue( true );
+
+		expect(
+			loadOptionalConfig( 'prettier', () => {
+				throw error;
+			} )
+		).toEqual( [] );
+
+		expect( debugLog ).toHaveBeenCalledWith( expect.stringContaining( 'prettier' ) );
+	} );
+
+	it( 'rethrows non-module-loading errors', () => {
+		const error = new Error( 'boom' );
+
+		isPackageInstalled.mockReturnValue( true );
+
+		expect( () =>
+			loadOptionalConfig( 'typescript', () => {
+				throw error;
+			} )
+		).toThrow( error );
+	} );
+} );

--- a/configs/index.js
+++ b/configs/index.js
@@ -5,14 +5,41 @@ const configs = {
 	formatting: require( './formatting' ),
 	javascript: require( './javascript' ),
 	jsdoc: require( './jsdoc' ),
-	prettier: require( './prettier' ),
-	react: require( './react' ),
 	recommended: require( './recommended' ),
-	testing: require( './testing' ),
-	typescript: require( './typescript' ),
 	'weak-javascript': require( './weak-javascript' ),
 	'weak-testing': require( './weak-testing' ),
 	'weak-typescript': require( './weak-typescript' ),
 };
+
+// Optional configs are lazy-loaded to avoid MODULE_NOT_FOUND crashes when
+// optional peers (typescript, react, jest, prettier) are not installed.
+// These are only accessed when explicitly requested (e.g., via direct extends)
+// or via recommended config, which guards their loading via loadOptionalConfig.
+const optionalConfigs = [ 'prettier', 'react', 'testing', 'typescript' ];
+
+function requireOptionalConfig( name ) {
+	switch ( name ) {
+		case 'prettier':
+			return require( './prettier' );
+		case 'react':
+			return require( './react' );
+		case 'testing':
+			return require( './testing' );
+		case 'typescript':
+			return require( './typescript' );
+		default:
+			throw new Error( `Unknown optional config: ${ name }` );
+	}
+}
+
+for ( const name of optionalConfigs ) {
+	Object.defineProperty( configs, name, {
+		enumerable: true,
+		configurable: true,
+		get() {
+			return requireOptionalConfig( name );
+		},
+	} );
+}
 
 module.exports = configs;

--- a/configs/recommended.js
+++ b/configs/recommended.js
@@ -1,22 +1,11 @@
-const isPackageInstalled = require( '../utils/is-package-installed' );
+const loadOptionalConfig = require( '../utils/load-optional-config' );
 
 /** @type import('eslint').Linter.Config[] */
 const configs = [ ...require( './javascript' ), ...require( './formatting' ) ];
 
-if ( isPackageInstalled( 'typescript' ) ) {
-	configs.push( ...require( './typescript' ) );
-}
-
-if ( isPackageInstalled( 'jest' ) ) {
-	configs.push( ...require( './testing' ) );
-}
-
-if ( isPackageInstalled( 'react' ) ) {
-	configs.push( ...require( './react' ) );
-}
-
-if ( isPackageInstalled( 'prettier' ) ) {
-	configs.push( ...require( './prettier' ) );
-}
+configs.push( ...loadOptionalConfig( 'typescript', () => require( './typescript' ) ) );
+configs.push( ...loadOptionalConfig( 'jest', () => require( './testing' ) ) );
+configs.push( ...loadOptionalConfig( 'react', () => require( './react' ) ) );
+configs.push( ...loadOptionalConfig( 'prettier', () => require( './prettier' ) ) );
 
 module.exports = configs;

--- a/init.js
+++ b/init.js
@@ -1,0 +1,6 @@
+const loadOptionalConfig = require( './utils/load-optional-config' );
+
+loadOptionalConfig( 'typescript', () => require( './configs/typescript' ) );
+loadOptionalConfig( 'jest', () => require( './configs/testing' ) );
+loadOptionalConfig( 'react', () => require( './configs/react' ) );
+loadOptionalConfig( 'prettier', () => require( './configs/prettier' ) );

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,25 @@
         "typescript": "^6.0.3"
       },
       "peerDependencies": {
-        "eslint": "^9.7.0"
+        "eslint": "^9.7.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "prettier": "^3.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "typescript": "^5.0.0 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        },
+        "prettier": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,25 @@
     "typescript-eslint": "^8.48.1"
   },
   "peerDependencies": {
-    "eslint": "^9.7.0"
+    "eslint": "^9.7.0",
+    "jest": "^29.0.0 || ^30.0.0",
+    "prettier": "^3.0.0",
+    "react": "^18.0.0 || ^19.0.0",
+    "typescript": "^5.0.0 || ^6.0.0"
+  },
+  "peerDependenciesMeta": {
+    "jest": {
+      "optional": true
+    },
+    "prettier": {
+      "optional": true
+    },
+    "react": {
+      "optional": true
+    },
+    "typescript": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@tsconfig/node20": "^20.1.8",

--- a/utils/is-package-installed.js
+++ b/utils/is-package-installed.js
@@ -31,7 +31,6 @@ debugLog( `Found package.json: ${ parent.__path || 'none' }` );
 module.exports = function isPackageInstalled( packageName ) {
 	const isDevDependency = Boolean( parent.devDependencies?.[ `${ packageName }` ] );
 	const isProdDependency = Boolean( parent.dependencies?.[ `${ packageName }` ] );
-	const isPeerDependency = Boolean( parent.peerDependencies?.[ `${ packageName }` ] );
 
-	return isDevDependency || isProdDependency || isPeerDependency;
+	return isDevDependency || isProdDependency;
 };

--- a/utils/is-package-installed.js
+++ b/utils/is-package-installed.js
@@ -31,6 +31,7 @@ debugLog( `Found package.json: ${ parent.__path || 'none' }` );
 module.exports = function isPackageInstalled( packageName ) {
 	const isDevDependency = Boolean( parent.devDependencies?.[ `${ packageName }` ] );
 	const isProdDependency = Boolean( parent.dependencies?.[ `${ packageName }` ] );
+	const isPeerDependency = Boolean( parent.peerDependencies?.[ `${ packageName }` ] );
 
-	return isDevDependency || isProdDependency;
+	return isDevDependency || isProdDependency || isPeerDependency;
 };

--- a/utils/load-optional-config.js
+++ b/utils/load-optional-config.js
@@ -1,0 +1,20 @@
+const debugLog = require( './debug-log' );
+const isPackageInstalled = require( './is-package-installed' );
+
+module.exports = function loadOptionalConfig( packageName, loadConfig ) {
+	if ( ! isPackageInstalled( packageName ) ) {
+		return [];
+	}
+
+	try {
+		return loadConfig();
+	} catch ( error ) {
+		if ( 'MODULE_NOT_FOUND' !== error?.code ) {
+			throw error;
+		}
+
+		debugLog( `Skipping optional config for ${ packageName }: ${ error.message }` );
+
+		return [];
+	}
+};

--- a/utils/load-optional-config.js
+++ b/utils/load-optional-config.js
@@ -13,6 +13,16 @@ module.exports = function loadOptionalConfig( packageName, loadConfig ) {
 			throw error;
 		}
 
+		// Only swallow the error if the missing module is the optional peer itself.
+		// This prevents masking errors from transitive dependencies or unrelated modules.
+		const missingModule = error.message?.match( /Cannot find module '([^']+)'/ )?.[ 1 ] || '';
+		const isOptionalPeerMissing =
+			missingModule === packageName || missingModule.startsWith( `${ packageName }/` );
+
+		if ( ! isOptionalPeerMissing ) {
+			throw error;
+		}
+
 		debugLog( `Skipping optional config for ${ packageName }: ${ error.message }` );
 
 		return [];


### PR DESCRIPTION
Adopt a hybrid dependency model aligning with ESLint shareable config and plugin packaging guidance. This allows consumers to opt in to optional framework/tooling packages (TypeScript, React, Jest, Prettier) while keeping runtime-required parser/plugin packages reliable and always installed.

Changes:
- Move typescript, react, jest, and prettier from devDependencies to peerDependencies and mark as optional via peerDependenciesMeta
- Expand is-package-installed() to detect optional peers in consumer package.json, enabling graceful handling in library contexts
- Add utils/load-optional-config.js for guarded loading of optional config stacks, preventing MODULE_NOT_FOUND crashes when optional peers are absent
- Refactor configs/recommended.js to use guarded loader for conditional TypeScript, testing, React, and Prettier config composition
- Create public init.js entrypoint to preload optional packages for consumers requiring upfront resolution
- Add comprehensive unit test coverage for guarded loader behavior

Package classification:
- Keep in dependencies: all runtime-loaded parsers, plugins, resolvers, eslint-config-prettier, globals, find-package-json, typescript-eslint
- Add as optional peers: typescript, react, jest, prettier
- Keep as peerDependency: eslint

Benefits:
- Consumers only install framework/tooling packages they actually use
- Backward compatible: existing consumers with all packages installed continue working without changes
- Clearer intent: optional ecosystem boundaries are explicit
- Low setup friction: recommended config still works with minimal consumer configuration
- Reliable defaults: parser/plugin stack remains guaranteed available

Documentation:
- Update README to clarify optional peer behavior and usage patterns
- Document init entrypoint for consumers requiring preloading
- Add guidance for JS-only consumers and framework-specific setups