### PR TITLE
fix(configs): resolve TypeScript import resolver by absolute path

### DIFF
--- a/__tests__/resolver-settings.js
+++ b/__tests__/resolver-settings.js
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+const fs = require( 'fs' );
+const path = require( 'path' );
+
+/**
+ * Internal dependencies
+ */
+const javascriptConfig = require( '../configs/javascript' );
+
+describe( 'resolver settings', () => {
+	it( 'configures eslint-plugin-import with an absolute resolver path', () => {
+		const entry = javascriptConfig.find(
+			item => item && item.settings && item.settings[ 'import/resolver' ]
+		);
+		expect( entry ).toBeDefined();
+
+		const resolverMap = entry.settings[ 'import/resolver' ];
+		const customKeys = Object.keys( resolverMap ).filter( name => 'node' !== name );
+		expect( customKeys ).toHaveLength( 1 );
+
+		const resolverKey = customKeys[ 0 ];
+		expect( path.isAbsolute( resolverKey ) ).toBe( true );
+		// eslint-disable-next-line security/detect-non-literal-fs-filename
+		expect( fs.existsSync( resolverKey ) ).toBe( true );
+		expect( resolverKey ).toEqual( expect.stringContaining( 'eslint-import-resolver-typescript' ) );
+
+		// eslint-disable-next-line security/detect-non-literal-require
+		const resolverModule = require( resolverKey );
+		expect( resolverModule.interfaceVersion ).toBe( 2 );
+		expect( typeof resolverModule.resolve ).toBe( 'function' );
+
+		// eslint-disable-next-line security/detect-object-injection
+		expect( typeof resolverMap[ resolverKey ] ).toBe( 'object' );
+
+		expect( resolverKey ).toBe( javascriptConfig.typescriptResolverPath );
+		expect( require( '..' ).typescriptResolverPath ).toBe( resolverKey );
+	} );
+
+	it( 'exposes typescriptResolverPath on the plugin entry point', () => {
+		const plugin = require( '..' );
+		expect( typeof plugin.typescriptResolverPath ).toBe( 'string' );
+		expect( path.isAbsolute( plugin.typescriptResolverPath ) ).toBe( true );
+	} );
+} );

--- a/configs/javascript.js
+++ b/configs/javascript.js
@@ -14,6 +14,15 @@ const SecurityPluginConfigs = require( 'eslint-plugin-security' );
 const UnusedImportsPlugin = require( 'eslint-plugin-unused-imports' );
 const globals = require( 'globals' );
 
+// Resolve the TypeScript resolver from this package's perspective so that
+// eslint-plugin-import can load it regardless of how the consuming project
+// hoists its dependencies. Passing the absolute path as the resolver name
+// bypasses `eslint-plugin-import`'s name-based lookup, which otherwise tries
+// to resolve `eslint-import-resolver-typescript` from each linted source
+// file's path and silently falls back to requiring `typescript` (the
+// compiler) when the resolver is nested under this plugin's node_modules.
+const typescriptResolverPath = require.resolve( 'eslint-import-resolver-typescript' );
+
 /** @type import('eslint').Linter.Config[] */
 module.exports = [
 	JsonPlugin.configs.recommended,
@@ -273,8 +282,10 @@ module.exports = [
 				node: {
 					extensions: [ '.js', '.jsx', '.ts', '.tsx', '.cjs', '.mjs', '.cts', '.mts' ],
 				},
-				typescript: 'eslint-import-resolver-typescript',
+				[ typescriptResolverPath ]: {},
 			},
 		},
 	},
 ];
+
+module.exports.typescriptResolverPath = typescriptResolverPath;

--- a/configs/recommended.js
+++ b/configs/recommended.js
@@ -19,4 +19,6 @@ if ( isPackageInstalled( 'prettier' ) ) {
 	configs.push( ...require( './prettier' ) );
 }
 
+configs.typescriptResolverPath = require( './javascript' ).typescriptResolverPath;
+
 module.exports = configs;

--- a/index.js
+++ b/index.js
@@ -2,5 +2,6 @@ const configs = require( './configs' );
 const plugin = require( './plugin' );
 
 plugin.configs = configs;
+plugin.typescriptResolverPath = require( './configs/javascript' ).typescriptResolverPath;
 
 module.exports = plugin;


### PR DESCRIPTION
## Summary

`configs/javascript.js` now resolves `eslint-import-resolver-typescript` via `require.resolve()` at config load time and uses the returned absolute path as the `settings['import/resolver']` map key. The resolved path is also exported from `configs/javascript`, re-exported from the top-level plugin as `plugin.typescriptResolverPath`, and re-attached on `configs/recommended` (which is built via array spread and would otherwise drop the property). A new `__tests__/resolver-settings.js` suite locks in the contract.

## Problem

`eslint-plugin-import` resolves the configured resolver by name from each linted source file's path (via `eslint-module-utils/resolve.js > requireResolver`). When a downstream project doesn't hoist `eslint-import-resolver-typescript` to its top-level `node_modules/` — which depends on the rest of the dependency graph — that lookup fails. The loader then falls back to `require('typescript')`, which is commonly hoisted (the TypeScript compiler), and reports:

```
Resolve error: typescript with invalid interface loaded as resolver
  import/no-extraneous-dependencies
Resolve error: typescript with invalid interface loaded as resolver
  import/order
```

The bug is layout-dependent, so it surfaces intermittently in downstream projects after unrelated dependency bumps reshuffle the lockfile. It was hit most recently in `Automattic/vip-go-internal-cli` while bumping `eslint`.

## Fix

Call `require.resolve('eslint-import-resolver-typescript')` once at config load time inside this package, where the resolver is always reachable as a direct dependency, and use that absolute path as the `import/resolver` map key. `eslint-module-utils` accepts an absolute path through its `createRequire(sourceFile).resolve(target)` branch and loads the resolver directly, bypassing the name-based lookup against the linted file's `node_modules` chain. The empty options object `{}` preserves the resolver defaults the previous string form was implicitly using.

The resolved path is exposed for downstream consumers at two access points:

- `require('@automattic/eslint-plugin-wpvip').typescriptResolverPath` — the canonical entry point.
- `wpvip.configs.javascript.typescriptResolverPath` and `wpvip.configs.recommended.typescriptResolverPath` — direct from the composed config arrays.

Consumers who want to pass custom `eslint-import-resolver-typescript` options (e.g. a custom `project` path) can write:

```js
const wpvip = require('@automattic/eslint-plugin-wpvip');

module.exports = [
    ...wpvip.configs.recommended,
    {
        settings: {
            'import/resolver': {
                node: { extensions: ['.js', '.jsx', '.ts', '.tsx'] },
                [wpvip.typescriptResolverPath]: { project: 'tsconfig.lint.json' },
            },
        },
    },
];
```

## Tests

New `__tests__/resolver-settings.js` suite asserts:

- the `import/resolver` map has exactly one non-`node` key;
- that key is an absolute filesystem path that exists on disk and contains the substring `eslint-import-resolver-typescript`;
- requiring the file yields `interfaceVersion === 2` and a function `resolve`;
- the map value is an object (the options bag);
- the map key equals both `configs.javascript.typescriptResolverPath` and `require('..').typescriptResolverPath` (internal-consistency contract);
- `plugin.typescriptResolverPath` is an absolute-path string.

Full suite on this branch: `npm test` 6 suites / 23 tests / 5 snapshots pass; `npm run lint` and `npm run check-types` clean.

## Tradeoffs

- `require.resolve` at config load time means a corrupted install where `eslint-import-resolver-typescript` is unreadable produces a hard config-load crash instead of per-file `Resolve error:`. Since the resolver is a direct `dependencies` entry (not `peerDependencies`), a completed `npm install` is guaranteed to ship it. Fail-fast is preferable to the previous behavior of silently falling back to the TypeScript compiler.
- `eslint --print-config` output now includes the resolver's absolute install path. This is cosmetic; users sharing config dumps in issues or chat should expect to see install-location-specific paths and redact if needed.

## Risk

Low. The change is confined to one library config plus two small surface additions (a property on the JS-config array export and a property on the top-level plugin). All existing tests pass; the new test pins the new contract.